### PR TITLE
added RESTORE lineage, rightscripts for rl10 chef server restore/backups

### DIFF
--- a/chef-server/CHANGELOG.md
+++ b/chef-server/CHANGELOG.md
@@ -1,0 +1,18 @@
+this is the changelog for Server Templates
+
+v2.0.2
+-----
+- added RESTORE input to chef server
+- added RL_10_CHEF_SERVER_BACKUP_VIA_RIGHTSCRIPTS.sh
+- added RL_10_CHEF_RESTORE_BACKUP_VIA_RIGHTSCRIPTS.sh
+
+v2.0.1
+------
+- update to rl10.6
+- update haproxy input pools to array - [21][]
+
+v2.0.0
+------
+- update everything to chef 12.
+- remove rightlink monitoring
+- add rs-base

--- a/chef-server/RL_10_CHEF_SERVER_BACKUP_VIA_RIGHTSCRIPTS.sh
+++ b/chef-server/RL_10_CHEF_SERVER_BACKUP_VIA_RIGHTSCRIPTS.sh
@@ -1,0 +1,138 @@
+#! /usr/bin/sudo /bin/bash
+# ---
+# RightScript Name: RL 10 CHEF SERVER BACKUP VIA RIGHTSCRIPTS
+# Description: RL 10 CHEF SERVER BACKUP VIA RIGHTSCRIPTS
+# Inputs:
+#   CHEF_SERVER_LOG_LEVEL:
+#     Category: CHEF
+#     Description: Chef solo Log Level
+#     Input Type: single
+#     Required: false
+#     Advanced: false
+#     Default: text:info
+#     Possible Values:
+#     - text:info
+#     - text:warn
+#     - text:fatal
+#     - text:error
+#     - text:debug
+#   BACKUP_LINEAGE:
+#     Category: Backup
+#     Description: Name of the backup
+#     Input Type: single
+#     Required: false
+#     Advanced: false
+#   STORAGE_ACCOUNT_ENDPOINT:
+#     Category: Backup
+#     Description: 'The endpoint URL for the storage cloud. This is used to override
+#       the default endpoint or for generic storage clouds such as Swift Example: http://endpoint_ip:5000/v2.0/tokens'
+#     Input Type: single
+#     Required: false
+#     Advanced: false
+#   STORAGE_ACCOUNT_ID:
+#     Category: Backup
+#     Description: "In order to write the Chef Server backup file to the specified cloud
+#       storage location you need to provide cloud authentication credentials\r\n    For
+#       Amazon S3, use your AWS secret access key\r\n     (e.g., cred:AWS_SECRET_ACCESS_KEY).\r\n
+#       \\    For Rackspace Cloud Files, use your Rackspace account API key     (e.g.,
+#       cred:RACKSPACE_AUTH_KEY). Example: cred:AWS_SECRET_ACCESS_KEY"
+#     Input Type: single
+#     Required: false
+#     Advanced: false
+#   STORAGE_ACCOUNT_PROVIDER:
+#     Category: Backup
+#     Description: "In order to write the Chef Server backup file to the specified cloud
+#       storage location\r\n   you need to provide cloud authentication credentials.\r\n
+#       \\   For Amazon S3, use your Amazon access key ID\r\n    (e.g., cred:AWS_ACCESS_KEY_ID).
+#       For Rackspace Cloud Files, use your\r\n     Rackspace login username (e.g.,
+#       cred:RACKSPACE_USERNAME).\r\n    \" For OpenStack Swift the format is: 'tenantID:username'.\r\n
+#       \\    Example: cred:AWS_ACCESS_KEY_ID"
+#     Input Type: single
+#     Required: false
+#     Advanced: false
+#     Possible Values:
+#     - text:aws
+#     - text:google
+#     - text:rackspace
+#   STORAGE_ACCOUNT_SECRET:
+#     Category: Backup
+#     Description: "In order to write the Chef Server backup file to the specified cloud
+#       storage location you need to provide cloud authentication credentials\r\n    For
+#       Amazon S3, use your AWS secret access key\r\n     (e.g., cred:AWS_SECRET_ACCESS_KEY).\r\n
+#       \\    For Rackspace Cloud Files, use your Rackspace account API key     (e.g.,
+#       cred:RACKSPACE_AUTH_KEY). Example: cred:AWS_SECRET_ACCESS_KEY"
+#     Input Type: single
+#     Required: false
+#     Advanced: false
+#   STORAGE_CONTAINER:
+#     Category: Backup
+#     Description: "The cloud storage location where the dump file will be saved to\r\n
+#       \\   or restored from. For Amazon S3, use the bucket name.\r\n    For Rackspace
+#       Cloud Files, use the container name.\r\n    Example: db_dump_bucket"
+#     Input Type: single
+#     Required: false
+#     Advanced: false
+#   REGION:
+#     Category: Backup
+#     Description: 'The cloud region where the bucket is located.   Example: us-west-2'
+#     Input Type: single
+#     Required: false
+#     Advanced: false
+# Attachments: []
+# ...
+
+set -e
+
+echo "installing awscli for s3 access"
+apt-get install -y awscli
+echo "installed awscli successfully"
+
+TIMESTAMP=`date '+%Y-%m-%d-%H-%M-%S'`
+OPSCODE_PG_USER="opscode-pgsql"
+PG_DUMP_BIN="/opt/opscode/embedded/bin/pg_dumpall"
+PG_DUMP_FILE="/tmp/postgresql-dump-${TIMESTAMP}.gz"
+TAR_BIN=`which tar`
+ 
+# TODO: Is this sufficient to make sure that the server is "quiet"?
+echo "Disabling outside access to Chef server..."
+chef-server-ctl stop opscode-erchef
+ 
+echo "Backing up Chef server database to [${PG_DUMP_FILE}]..."
+cd /tmp
+sudo -E -u ${OPSCODE_PG_USER} bash -c "${PG_DUMP_BIN} -c | gzip --fast > ${PG_DUMP_FILE}"
+ 
+echo "Stopping all Chef server processes..."
+chef-server-ctl stop
+
+echo "Backing up Chef server database to [${PG_DUMP_FILE}]..."
+cd /tmp
+sudo -E -u ${OPSCODE_PG_USER} bash -c "${PG_DUMP_BIN} -c | gzip --fast > ${PG_DUMP_FILE}"
+ 
+echo "Stopping all Chef server processes..."
+chef-server-ctl stop
+
+ETC_OPSCODE_BACKUP="/etc/opscode"
+VAR_OPT_OPSCODE_BACKUP="/var/opt/opscode"
+FULL_BACKUP="/tmp/chef-server-backup-${BACKUP_LINEAGE}-${TIMESTAMP}.tar.gz"
+LATEST_BACKUP="chef-server-backup-${BACKUP_LINEAGE}-latest.tar.gz"
+echo "Backing up all Chef server assets..."
+${TAR_BIN} cvfzp ${FULL_BACKUP} ${ETC_OPSCODE_BACKUP} ${VAR_OPT_OPSCODE_BACKUP} ${PG_DUMP_FILE}
+ 
+echo "Removing extra files..."
+rm -f ${PG_DUMP_FILE}
+ 
+echo "Starting all Chef server processes..."
+chef-server-ctl start
+ 
+echo "Backup complete!"
+echo "Backup located at [${FULL_BACKUP}]."
+
+echo "Pushing backup to s3://[${STORAGE_CONTAINER}]"
+cd /tmp
+
+aws s3 --region $REGION cp $FULL_BACKUP s3://$STORAGE_CONTAINER/
+aws s3 --region $REGION cp $FULL_BACKUP s3://$STORAGE_CONTAINER/$LATEST_BACKUP
+echo "Successfully pushed $FULL_BACKUP to S3:[${STORAGE_CONTAINER}]"
+
+echo "Removing Backup"
+rm -f ${FULL_BACKUP}

--- a/chef-server/RL_10_CHEF_SERVER_RESTORE_VIA_RIGHTSCRIPTS.sh
+++ b/chef-server/RL_10_CHEF_SERVER_RESTORE_VIA_RIGHTSCRIPTS.sh
@@ -1,0 +1,185 @@
+#! /usr/bin/sudo /bin/bash
+# ---
+# RightScript Name: RL 10 CHEF SERVER RESTORE VIA RIGHTSCRIPTS
+# Description: RL 10 CHEF SERVER BACKUP VIA RIGHTSCRIPTS
+# Inputs:
+#   CHEF_SERVER_LOG_LEVEL:
+#     Category: CHEF
+#     Description: Chef solo Log Level
+#     Input Type: single
+#     Required: false
+#     Advanced: false
+#     Default: text:info
+#     Possible Values:
+#     - text:info
+#     - text:warn
+#     - text:fatal
+#     - text:error
+#     - text:debug
+#   BACKUP_LINEAGE:
+#     Category: Backup
+#     Description: Name of the backup
+#     Input Type: single
+#     Required: false
+#     Advanced: false
+#   STORAGE_ACCOUNT_ENDPOINT:
+#     Category: Backup
+#     Description: 'The endpoint URL for the storage cloud. This is used to override
+#       the default endpoint or for generic storage clouds such as Swift Example: http://endpoint_ip:5000/v2.0/tokens'
+#     Input Type: single
+#     Required: false
+#     Advanced: false
+#   STORAGE_ACCOUNT_ID:
+#     Category: Backup
+#     Description: "In order to write the Chef Server backup file to the specified cloud
+#       storage location you need to provide cloud authentication credentials\r\n    For
+#       Amazon S3, use your AWS secret access key\r\n     (e.g., cred:AWS_SECRET_ACCESS_KEY).\r\n
+#       \\    For Rackspace Cloud Files, use your Rackspace account API key     (e.g.,
+#       cred:RACKSPACE_AUTH_KEY). Example: cred:AWS_SECRET_ACCESS_KEY"
+#     Input Type: single
+#     Required: false
+#     Advanced: false
+#   STORAGE_ACCOUNT_PROVIDER:
+#     Category: Backup
+#     Description: "In order to write the Chef Server backup file to the specified cloud
+#       storage location\r\n   you need to provide cloud authentication credentials.\r\n
+#       \\   For Amazon S3, use your Amazon access key ID\r\n    (e.g., cred:AWS_ACCESS_KEY_ID).
+#       For Rackspace Cloud Files, use your\r\n     Rackspace login username (e.g.,
+#       cred:RACKSPACE_USERNAME).\r\n    \" For OpenStack Swift the format is: 'tenantID:username'.\r\n
+#       \\    Example: cred:AWS_ACCESS_KEY_ID"
+#     Input Type: single
+#     Required: false
+#     Advanced: false
+#     Possible Values:
+#     - text:aws
+#     - text:google
+#     - text:rackspace
+#   STORAGE_ACCOUNT_SECRET:
+#     Category: Backup
+#     Description: "In order to write the Chef Server backup file to the specified cloud
+#       storage location you need to provide cloud authentication credentials\r\n    For
+#       Amazon S3, use your AWS secret access key\r\n     (e.g., cred:AWS_SECRET_ACCESS_KEY).\r\n
+#       \\    For Rackspace Cloud Files, use your Rackspace account API key     (e.g.,
+#       cred:RACKSPACE_AUTH_KEY). Example: cred:AWS_SECRET_ACCESS_KEY"
+#     Input Type: single
+#     Required: false
+#     Advanced: false
+#   STORAGE_CONTAINER:
+#     Category: Backup
+#     Description: "The cloud storage location where the dump file will be saved to\r\n
+#       \\   or restored from. For Amazon S3, use the bucket name.\r\n    For Rackspace
+#       Cloud Files, use the container name.\r\n    Example: db_dump_bucket"
+#     Input Type: single
+#     Required: false
+#     Advanced: false
+#   REGION:
+#     Category: Backup
+#     Description: 'The cloud region where the bucket is located.   Example: us-west-2'
+#     Input Type: single
+#     Required: false
+#     Advanced: false
+#   RESTORE_LINEAGE:
+#     Category: Backup
+#     Description: Name of the restore file. e.g. latest
+#     Input Type: single
+#     Required: false
+#     Advanced: false
+# Attachments: []
+# ...
+
+set -e
+
+HOME=/home/rightscale
+/sbin/mkhomedir_helper rightlink
+
+set +e
+echo "installing awscli for s3 access"
+apt-get install -y awscli jq
+echo "installed awscli successfully"
+
+TIMESTAMP=`date '+%Y-%m-%d-%H-%M-%S'`
+OPSCODE_PG_USER="opscode-pgsql"
+WORKING_DIR="/tmp/chef-server-restore"
+
+BACKUP_FILE="chef-server-backup-$BACKUP_LINEAGE-$RESTORE_LINEAGE.tar.gz"
+
+#BACKUP_FILE="$RESTORE_LINEAGE.tgz"
+
+#BACKUP_PATH=$WORKING_DIR/$RESTORE_LINEAGE
+
+echo "Creating working directory: [${WORKING_DIR}]..."
+mkdir -p ${WORKING_DIR}
+
+echo "Storage Container: [${STORAGE_CONTAINER}]..."
+
+echo "Full Path of File: [${STORAGE_CONTAINER}][${BACKUP_FILE}]..."
+echo "Pulling down the backup from S3:[${STORAGE_CONTAINER}][${BACKUP_FILE}]...  "
+
+cd ${WORKING_DIR}
+aws s3 --region $REGION cp s3://$STORAGE_CONTAINER/$BACKUP_FILE .
+
+if [ ! -f "${BACKUP_FILE}" ] ; then
+  echo "ERROR: [${BACKUP_FILE}] does not look like a proper backup file."
+  exit 1
+else
+  echo "Successfully downloaded chef-server backup file"
+fi
+ 
+cd ${WORKING_DIR}
+tar xvfzp ${BACKUP_FILE} --exclude='var/opt/opscode/drbd/data/postgresql_9.2' -C ${WORKING_DIR}
+ 
+echo "Stopping all Chef server processes..."
+chef-server-ctl stop
+ 
+ETC_OPSCODE_BACKUP="/etc/opscode"
+echo "Deleting Chef server directory: [${ETC_OPSCODE_BACKUP}]..."
+rm -rf ${ETC_OPSCODE_BACKUP}
+ 
+VAR_OPT_OPSCODE_BACKUP="/var/opt/opscode"
+echo "Deleting Chef server directory: [${VAR_OPT_OPSCODE_BACKUP}]..."
+rm -rf ${VAR_OPT_OPSCODE_BACKUP}
+ 
+echo "Restoring [${ETC_OPSCODE_BACKUP}] from backup..."
+cp -rp ${WORKING_DIR}/etc/opscode ${ETC_OPSCODE_BACKUP}
+ 
+echo "Restoring [${VAR_OPT_OPSCODE_BACKUP}] from backup..."
+cp -rp ${WORKING_DIR}/var/opt/opscode ${VAR_OPT_OPSCODE_BACKUP}
+ 
+echo "Starting Chef server postgresql service..."
+chef-server-ctl start postgresql
+ 
+echo "Waiting for postgresql service to start up..."
+# TODO - see if we can determine that this is up for certain; for now, 15 seconds works fine
+sleep 15
+ 
+echo "Finding database backup file in [${WORKING_DIR}]..."
+DB_BACKUP_FILE=`find ${WORKING_DIR}/tmp -maxdepth 1 -type f -name "postgresql-dump-*.gz" | head -n1`
+echo "Found database backup file: [${DB_BACKUP_FILE}]."
+ 
+echo "Restoring postgresql data from [${DB_BACKUP_FILE}]..."
+sudo -E -u ${OPSCODE_PG_USER} bash -c "gunzip -c ${DB_BACKUP_FILE} | /opt/opscode/embedded/bin/psql -U '${OPSCODE_PG_USER}' -d postgres"
+ 
+#echo "Fixing Reporting SQL Password"
+#opscode_pgsql_password=`jq .private_chef.postgresql.db_superuser_password /etc/opscode/chef-server-running.json`
+#jq .postgresql.db_superuser_password=$opscode_pgsql_password /etc/opscode-reporting/opscode-reporting-secrets.json > /etc/opscode-reporting/tmp_secrets.json
+#mv /etc/opscode-reporting/tmp_secrets.json /etc/opscode-reporting/opscode-reporting-secrets.json
+
+echo "Reconfiguring Chef server..."
+chef-server-ctl reconfigure
+ 
+##echo "Running Chef server upgrade process. This may take some time..."
+##chef-server-ctl upgrade
+
+#echo "Running Chef Reporting Service management console reconfigure."
+#opscode-reporting-ctl reconfigure
+
+echo "Running Chef Server management console reconfigure. This may take about ~45 seconds"
+opscode-manage-ctl reconfigure
+
+echo "Restarting Chef server processes..."
+chef-server-ctl restart
+ 
+echo "Removing working directory..."
+rm -rf ${WORKING_DIR}
+ 
+echo "Restore complete!"

--- a/chef-server/server_template.yml
+++ b/chef-server/server_template.yml
@@ -62,6 +62,8 @@ RightScripts:
   - RL10_Chef_Server_Backup.sh
   - RL10_Chef_Server_Restore.sh
   - RL10_Chef_Server_Schedule_Backup.sh
+  - RL_10_CHEF_SERVER_BACKUP_VIA_RIGHTSCRIPTS.sh
+  - RL_10_CHEF_SERVER_RESTORE_VIA_RIGHTSCRIPTS.sh
   - Name: RL10 Linux Setup Automatic Upgrade
     Revision: 4
     Publisher: RightScale


### PR DESCRIPTION
Gui of chef console doesn't work.  However, restore can be validated via command line.
Backedup Server:
https://us-3.rightscale.com/acct/82326/servers/1500035003#info

Restored Server
https://us-3.rightscale.com/acct/82326/servers/1500042003

Original:

Reestore:
TusharSghtScale:chefserverrestoretest2 tushar$ knife user list
tushar
![chef_manage](https://cloud.githubusercontent.com/assets/5281839/25355530/f6dfa1b2-2904-11e7-8c73-5daa5de9a5cc.png)


TusharSghtScale:chefserverrestoretest2 tushar$ knife cookbook list -a
apache2               3.2.2
application           4.1.6
application_php       2.0.2
apt                   5.0.1
build-essential       7.0.3
chef-sugar            3.4.0
collectd              2.2.2
collectd_plugins      2.1.3
compat_resource       12.16.3
cpu                   1.0.0
curl                  2.0.3
database              6.1.1
dmg                   3.1.0
ephemeral_lvm         2.0.0
fake                  0.1.0
git                   5.0.2
haproxy               2.0.3
hostsfile             2.4.5
iis                   5.0.5
lvm                   3.1.0
machine_tag           2.0.1
mariadb               1.0.1
marker                2.0.0
mingw                 1.2.5
mysql                 8.2.0
mysql2_chef_gem       1.1.0
ntp                   3.3.1
ohai                  4.2.3
openssl               6.1.1
php                   2.2.0
poise                 2.7.1
poise-service         1.4.2
postgresql            6.0.1
rightscale_tag        2.0.0
rs-application_php    2.0.0
rs-base               2.0.0
rs-haproxy            2.0.0
rsc_remote_recipe     10.1.0
rsyslog               5.1.0
seven_zip             2.0.2
swap                  0.3.8
windows               2.1.1
xml                   3.1.1
yum                   4.1.0
yum-epel              2.1.1
yum-mysql-community   2.0.3