### PR TITLE
Fix storage toolbox timestamp logic

### DIFF
--- a/storage-toolbox/CHANGELOG.md
+++ b/storage-toolbox/CHANGELOG.md
@@ -1,0 +1,4 @@
+### 2017-04-27:
+ * Fixed `STORE_RESTORE_TIMESTAMP` and `STORE_RESTORE_LINEAGE` naming mixup.
+ * Updated JSON code to properly output `STOR_RESTORE_LINEAGE` and `STORE_RESTORE_TIMESTAMP` variables for `chef.json`.
+ 

--- a/storage-toolbox/Storage_Toolbox_Stripe-chef.sh
+++ b/storage-toolbox/Storage_Toolbox_Stripe-chef.sh
@@ -108,20 +108,20 @@ fi
 
 restore_lineage=''
 if [ -n "$STOR_RESTORE_LINEAGE" ];then
-comma=''
-  if [ -n "$STOR_RESTORE_LINEAGE" ];then
-   comma=","
-  fi
   restore_lineage="\"lineage\":\"$STOR_RESTORE_LINEAGE\"$comma"
 fi
 
 restore_timestamp=''
-if [ -n "$STOR_RESTORE_LINEAGE" ];then
-  restore_timestamp="\"timestamp\":\"$STOR_RESTORE_LINEAGE\""
+comma=""
+if [ -n "$STOR_RESTORE_TIMESTAMP" ];then
+  comma=","
+  restore_timestamp="\"timestamp\":\"$STOR_RESTORE_TIMESTAMP\""
 fi
+
 if [ -e $chef_dir/chef.json ]; then
   rm -f $chef_dir/chef.json
 fi
+
 # add the rightscale env variables to the chef runtime attributes
 # http://docs.rightscale.com/cm/ref/environment_inputs.html
 cat <<EOF> $chef_dir/chef.json
@@ -149,7 +149,7 @@ cat <<EOF> $chef_dir/chef.json
 
    },
    "restore":{
-     $restore_lineage
+     $restore_lineage$comma
      $restore_timestamp
    }
 

--- a/storage-toolbox/Storage_Toolbox_Stripe-chef.sh
+++ b/storage-toolbox/Storage_Toolbox_Stripe-chef.sh
@@ -36,7 +36,7 @@
 #     Input Type: single
 #     Required: false
 #     Advanced: false
-#   STOR_RESTORE_LINEAGE:
+#   STOR_RESTORE_TIMESTAMP:
 #     Category: Storage
 #     Description: 'The timestamp (in seconds since UNIX epoch) to select a backup to
 #       restore from. The backup selected will have been created on or before this timestamp.

--- a/storage-toolbox/Storage_Toolbox_Volume-chef.sh
+++ b/storage-toolbox/Storage_Toolbox_Volume-chef.sh
@@ -99,16 +99,14 @@ fi
 
 restore_lineage=''
 if [ -n "$STOR_RESTORE_LINEAGE" ];then
-comma=''
-  if [ -n "$STOR_RESTORE_LINEAGE" ];then
-   comma=","
-  fi
   restore_lineage="\"lineage\":\"$STOR_RESTORE_LINEAGE\"$comma"
 fi
 
 restore_timestamp=''
-if [ -n "$STOR_RESTORE_LINEAGE" ];then
-  restore_timestamp="\"timestamp\":\"$STOR_RESTORE_LINEAGE\""
+comma=""
+if [ -n "$STOR_RESTORE_TIMESTAMP" ];then
+  comma=","
+  restore_timestamp="\"timestamp\":\"$STOR_RESTORE_TIMESTAMP\""
 fi
 
 if [ -e $chef_dir/chef.json ]; then
@@ -141,7 +139,7 @@ cat <<EOF> $chef_dir/chef.json
      "volume_size":"$DEVICE_VOLUME_SIZE"
    },
    "restore":{
-     $restore_lineage
+     $restore_lineage$comma
      $restore_timestamp
    }
 

--- a/storage-toolbox/Storage_Toolbox_Volume-chef.sh
+++ b/storage-toolbox/Storage_Toolbox_Volume-chef.sh
@@ -44,7 +44,7 @@
 #     Input Type: single
 #     Required: false
 #     Advanced: false
-#   STOR_RESTORE_LINEAGE:
+#   STOR_RESTORE_TIMESTAMP:
 #     Category: Storage
 #     Description: 'The timestamp (in seconds since UNIX epoch) to select a backup to
 #       restore from. The backup selected will have been created on or before this timestamp.


### PR DESCRIPTION
The timestamp variable was incorrectly named LINEAGE.
Also fixed logic to properly append comma if TIMESTAMP is set in json output.