### PR TITLE
Added Backup Cron Job for Chef Server Backups

### DIFF
--- a/chef-server/CHANGELOG.md
+++ b/chef-server/CHANGELOG.md
@@ -2,7 +2,7 @@ this is the changelog for Server Templates
 
 v2.0.2
 -----
-- added RL10_Chef_Server_Schedule_Backups_FOR_RIGHTSCRIPTS_BACKUPS.sh
+- RL10_Chef_Server_Schedule_Cron_For_Backups_Via_RightScripts.sh
 
 v2.0.2
 -----

--- a/chef-server/CHANGELOG.md
+++ b/chef-server/CHANGELOG.md
@@ -2,6 +2,10 @@ this is the changelog for Server Templates
 
 v2.0.2
 -----
+- added RL10_Chef_Server_Schedule_Backups_FOR_RIGHTSCRIPTS_BACKUPS.sh
+
+v2.0.2
+-----
 - added RESTORE input to chef server
 - added RL_10_CHEF_SERVER_BACKUP_VIA_RIGHTSCRIPTS.sh
 - added RL_10_CHEF_RESTORE_BACKUP_VIA_RIGHTSCRIPTS.sh

--- a/chef-server/RL10_Chef_Server_Schedule_Backups_FOR_RIGHTSCRIPTS_BACKUPS.sh
+++ b/chef-server/RL10_Chef_Server_Schedule_Backups_FOR_RIGHTSCRIPTS_BACKUPS.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/sudo /bin/bash
 # ---
 # RightScript Name: RL10_Chef_Server_Schedule_Backups_FOR_RIGHTSCRIPTS_BACKUPS.sh 
-# Description: Creates a cron job that kicks off backups via RL_10_CHEF_SERVER_BACKUP_VIA_RIGHTSCRIPTS
-#   Add cron job for chef backups
-#   NOTE: While this server is backing up (~70sec) chef will be stopped. Instances and Knife commands will fail during this time.
+# Description: "Creates a cron job that kicks off backups via RL_10_CHEF_SERVER_BACKUP_VIA_RIGHTSCRIPTS. NOTE: While this server is backing up (~70sec) chef will be stopped. Instances and Knife commands will fail during this time."
 # Inputs:
 #   SCHEDULE:
 #     Category: CHEF

--- a/chef-server/RL10_Chef_Server_Schedule_Backups_FOR_RIGHTSCRIPTS_BACKUPS.sh
+++ b/chef-server/RL10_Chef_Server_Schedule_Backups_FOR_RIGHTSCRIPTS_BACKUPS.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/sudo /bin/bash
+# ---
+# RightScript Name: RL10_Chef_Server_Schedule_Backups_FOR_RIGHTSCRIPTS_BACKUPS.sh 
+# Description: Creates a cron job that kicks off backups via RL_10_CHEF_SERVER_BACKUP_VIA_RIGHTSCRIPTS
+#   Add cron job for chef backups
+#   NOTE: While this server is backing up (~70sec) chef will be stopped. Instances and Knife commands will fail during this time.
+# Inputs:
+#   SCHEDULE:
+#     Category: CHEF
+#     Description: Cron style time schedule. (Defaults to 11am UTC, 1 11 * * *)
+#     Input Type: single
+#     Required: true
+#     Advanced: false
+#     Default: text:1 11 * * *
+# Attachments: []
+# ...
+
+set ex
+
+if [ -f /etc/cron.d/chef-backup ]; then
+  rm -rf /etc/cron.d/chef-backup
+fi
+  
+cat << EOF > /etc/cron.d/chef-backup
+$SCHEDULE root /usr/local/bin/rsc rl10 run_right_script /rll/run/right_script right_script=RL-10-CHEF-SERVER-BACKUP-VIA-RIGHTSCRIPTS.sh
+
+EOF

--- a/chef-server/RL10_Chef_Server_Schedule_Cron_For_Backups_Via_RightScripts.sh
+++ b/chef-server/RL10_Chef_Server_Schedule_Cron_For_Backups_Via_RightScripts.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/sudo /bin/bash
 # ---
-# RightScript Name: RL10_Chef_Server_Schedule_Backups_FOR_RIGHTSCRIPTS_BACKUPS.sh 
+# RightScript Name: RL10 Chef Server Schedule Cron For Backups Via RightScripts 
 # Description: "Creates a cron job that kicks off backups via RL_10_CHEF_SERVER_BACKUP_VIA_RIGHTSCRIPTS. NOTE: While this server is backing up (~70sec) chef will be stopped. Instances and Knife commands will fail during this time."
 # Inputs:
 #   SCHEDULE:

--- a/chef-server/RL10_Chef_Server_Schedule_Cron_For_Backups_Via_RightScripts.sh
+++ b/chef-server/RL10_Chef_Server_Schedule_Cron_For_Backups_Via_RightScripts.sh
@@ -20,6 +20,6 @@ if [ -f /etc/cron.d/chef-backup ]; then
 fi
   
 cat << EOF > /etc/cron.d/chef-backup
-$SCHEDULE root /usr/local/bin/rsc rl10 run_right_script /rll/run/right_script right_script=RL-10-CHEF-SERVER-BACKUP-VIA-RIGHTSCRIPTS.sh
+$SCHEDULE root /usr/local/bin/rsc rl10 run_right_script /rll/run/right_script right_script="RL 10 CHEF SERVER BACKUP VIA RIGHTSCRIPTS"
 
 EOF

--- a/chef-server/server_template.yml
+++ b/chef-server/server_template.yml
@@ -54,7 +54,7 @@ RightScripts:
     Revision: 4
     Publisher: RightScale
   - RL10_Chef_Server_Install.sh
-  - RL10_Chef_Server_Schedule_Backups_FOR_RIGHTSCRIPTS_BACKUPS.sh
+  - RL10_Chef_Server_Schedule_Cron_For_Backups_Via_RightScripts.sh
   Decommission:
   - Name: RL10 Linux Shutdown Reason
     Revision: 5

--- a/chef-server/server_template.yml
+++ b/chef-server/server_template.yml
@@ -54,6 +54,7 @@ RightScripts:
     Revision: 4
     Publisher: RightScale
   - RL10_Chef_Server_Install.sh
+  - RL10_Chef_Server_Schedule_Backups_FOR_RIGHTSCRIPTS_BACKUPS.sh
   Decommission:
   - Name: RL10 Linux Shutdown Reason
     Revision: 5


### PR DESCRIPTION
Added Backup Cron Job for Chef Server Backups

tusharshah@ip-10-146-22-234:~$ cat /etc/cron.d/chef-backup 
1 11 * * * root /usr/local/bin/rsc rl10 run_right_script /rll/run/right_script right_script="RL 10 CHEF SERVER BACKUP VIA RIGHTSCRIPTS"

Validated it by manually running the entries in chef-backup:
root@ip-10-146-22-234:/etc/cron.d# /usr/local/bin/rsc rl10 run_right_script /rll/run/right_script right_script="RL 10 CHEF SERVER BACKUP VIA RIGHTSCRIPTS"
