### PR TITLE
Haproxy inputs

### DIFF
--- a/haproxy/CHANGELOG.md
+++ b/haproxy/CHANGELOG.md
@@ -1,0 +1,16 @@
+this is the changelog for Server Templates
+
+v2.0.2
+-----
+- inter, rise, fall, and maxconn as inputs
+
+v2.0.1
+------
+- update to rl10.6
+- update haproxy input pools to array - [21][]
+
+v2.0.0
+------
+- update everything to chef 12.
+- remove rightlink monitoring
+- add rs-base

--- a/haproxy/CHANGELOG.md
+++ b/haproxy/CHANGELOG.md
@@ -2,7 +2,7 @@ this is the changelog for Server Templates
 
 v2.0.2
 -----
-- inter, rise, fall, and maxconn as inputs
+- added inter, rise, fall, and maxconn as inputs
 
 v2.0.1
 ------

--- a/haproxy/HAProxy_Frontend-chef
+++ b/haproxy/HAProxy_Frontend-chef
@@ -114,7 +114,7 @@
 #     Input Type: single
 #     Required: false
 #     Advanced: false
-#   MAXCONN:
+#   MEMBER_MAXCONN:
 #     Category: Load Balancer
 #     Description: 'Sets the maximum per-process number of concurrent connections to <number>.
 #        Proxies will stop accepting connections when this limit is reached. This value defaults to 4096.'
@@ -192,7 +192,7 @@ cat <<EOF> $chef_dir/chef.json
     "stats_uri": "$STATUS_URI"
   },
     "haproxy": {
-    "member_max_connections": "$MAXCONN"
+    "member_max_connections": "$MEMBER_MAXCONN"
     },
   "remote_recipe": {
     "pool_name": "$POOL_NAME",

--- a/haproxy/HAProxy_Frontend-chef
+++ b/haproxy/HAProxy_Frontend-chef
@@ -114,6 +114,14 @@
 #     Input Type: single
 #     Required: false
 #     Advanced: false
+#   MAXCONN:
+#     Category: Load Balancer
+#     Description: 'Sets the maximum per-process number of concurrent connections to <number>.
+#        Proxies will stop accepting connections when this limit is reached. This value defaults to 4096.'
+#     Input Type: single
+#     Required: false
+#     Advanced: false
+#     Default: text:'4096'
 # Attachments: []
 # ...
 
@@ -183,6 +191,9 @@ cat <<EOF> $chef_dir/chef.json
     $stats_user
     "stats_uri": "$STATUS_URI"
   },
+    "haproxy": {
+    "member_max_connections": "$MAXCONN"
+    },
   "remote_recipe": {
     "pool_name": "$POOL_NAME",
     "application_server_id": "$APPLICATION_SERVER_ID",

--- a/haproxy/HAProxy_Frontend-chef
+++ b/haproxy/HAProxy_Frontend-chef
@@ -121,7 +121,7 @@
 #     Input Type: single
 #     Required: false
 #     Advanced: false
-#     Default: text:'4096'
+#     Default: text:4096
 # Attachments: []
 # ...
 

--- a/haproxy/HAProxy_Install-chef
+++ b/haproxy/HAProxy_Install-chef
@@ -89,7 +89,7 @@
 #     Input Type: single
 #     Required: false
 #     Advanced: false
-#     Default: text:'2'
+#     Default: text:2
 #   MEMBER_INTER:
 #     Category: Load Balancer
 #     Description: 'The inter parameter sets the interval between two consecutive health checks
@@ -98,7 +98,7 @@
 #     Input Type: single
 #     Required: false
 #     Advanced: false
-#     Default: text:'300'
+#     Default: text:300
 #   MEMBER_RISE:
 #     Category: Load Balancer
 #     Description: 'The rise parameter states that a server will be considered as operational
@@ -107,7 +107,7 @@
 #     Input Type: single
 #     Required: false
 #     Advanced: false
-#     Default: text:'3'
+#     Default: text:3
 # Attachments: []
 # ...
 

--- a/haproxy/HAProxy_Install-chef
+++ b/haproxy/HAProxy_Install-chef
@@ -182,11 +182,11 @@ cat <<EOF> $chef_dir/chef.json
     "health_check_uri": "$HEALTH_CHECK_URI",
     "session_stickiness": "$SESSION_STICKINESS",
     "maxconn": "$MAXCONN",
-    "backend":{
-    "inter": "$INTER",
-    "fall": "$FALL",
-    "rise": "$RISE"
-    }
+    "backend": {
+     "inter": "$INTER",
+     "fall": "$FALL",
+     "rise": "$RISE"
+    },
     $ssl_cert
     $ssl_incoming_port
     $stats_password

--- a/haproxy/HAProxy_Install-chef
+++ b/haproxy/HAProxy_Install-chef
@@ -188,6 +188,10 @@ cat <<EOF> $chef_dir/chef.json
     "stats_user":"$STATS_USER",
     "stats_uri": "$STATUS_URI",
     "pools":["$POOLS"]
+    "inter": "$INTER",
+    "rise": "$RISE",
+    "fall": "$FALL",
+    "maxconn":"$MAXCONN"
   },
   "run_list": ["recipe[apt]","recipe[rs-haproxy]","recipe[rs-haproxy::tags]",
   "recipe[rs-haproxy::collectd]"]

--- a/haproxy/HAProxy_Install-chef
+++ b/haproxy/HAProxy_Install-chef
@@ -181,11 +181,13 @@ cat <<EOF> $chef_dir/chef.json
     "balance_algorithm": "$BALANCE_ALGORITHM",
     "health_check_uri": "$HEALTH_CHECK_URI",
     "session_stickiness": "$SESSION_STICKINESS",
-    "maxconn": "$MAXCONN",
     "backend": {
      "inter": "$INTER",
      "fall": "$FALL",
      "rise": "$RISE"
+    },
+  "haproxy": {
+    "maxconn": "$MAXCONN",
     },
     $ssl_cert
     $ssl_incoming_port

--- a/haproxy/HAProxy_Install-chef
+++ b/haproxy/HAProxy_Install-chef
@@ -187,7 +187,7 @@ cat <<EOF> $chef_dir/chef.json
      "rise": "$RISE"
     },
   "haproxy": {
-    "maxconn": "$MAXCONN",
+    "maxconn": "$MAXCONN"
     },
     $ssl_cert
     $ssl_incoming_port

--- a/haproxy/HAProxy_Install-chef
+++ b/haproxy/HAProxy_Install-chef
@@ -181,6 +181,10 @@ cat <<EOF> $chef_dir/chef.json
     "balance_algorithm": "$BALANCE_ALGORITHM",
     "health_check_uri": "$HEALTH_CHECK_URI",
     "session_stickiness": "$SESSION_STICKINESS",
+    "maxconn":"$MAXCONN",
+    "backend/inter": "$INTER",
+    "backend/rise": "$RISE",
+    "backend/fall": "$FALL",
     $ssl_cert
     $ssl_incoming_port
     $stats_password
@@ -188,10 +192,6 @@ cat <<EOF> $chef_dir/chef.json
     "stats_user":"$STATS_USER",
     "stats_uri": "$STATUS_URI",
     "pools":["$POOLS"]
-    "inter": "$INTER",
-    "rise": "$RISE",
-    "fall": "$FALL",
-    "maxconn":"$MAXCONN"
   },
   "run_list": ["recipe[apt]","recipe[rs-haproxy]","recipe[rs-haproxy::tags]",
   "recipe[rs-haproxy::collectd]"]

--- a/haproxy/HAProxy_Install-chef
+++ b/haproxy/HAProxy_Install-chef
@@ -181,10 +181,12 @@ cat <<EOF> $chef_dir/chef.json
     "balance_algorithm": "$BALANCE_ALGORITHM",
     "health_check_uri": "$HEALTH_CHECK_URI",
     "session_stickiness": "$SESSION_STICKINESS",
-    "maxconn":"$MAXCONN",
-    "backend": {"inter":"$INTER"}
-    "backend": {"rise":"$RISE"}
-    "backend": {"fall":"$FALL"}
+    "maxconn": "$MAXCONN",
+    "backend":{
+    "inter": "$INTER",
+    "fall": "$FALL",
+    "rise": "$RISE"
+    }
     $ssl_cert
     $ssl_incoming_port
     $stats_password

--- a/haproxy/HAProxy_Install-chef
+++ b/haproxy/HAProxy_Install-chef
@@ -82,7 +82,7 @@
 #     Required: false
 #     Advanced: false
 #     Default: text:/haproxy-status
-#   FALL:
+#   MEMBER_FALL:
 #     Category: Load Balancer
 #     Description: 'The number of consecutive invalid health checks before considering the server as DOWN. 
 #           Default value is 2.  This is for the backend pool.'
@@ -90,7 +90,7 @@
 #     Required: false
 #     Advanced: false
 #     Default: text:'2'
-#   INTER:
+#   MEMBER_INTER:
 #     Category: Load Balancer
 #     Description: 'The inter parameter sets the interval between two consecutive health checks
 #         to <delay> milliseconds. If left unspecified, the delay defaults to 2000 ms(2 seconds). 
@@ -99,7 +99,7 @@
 #     Required: false
 #     Advanced: false
 #     Default: text:'300'
-#   RISE:
+#   MEMBER_RISE:
 #     Category: Load Balancer
 #     Description: 'The rise parameter states that a server will be considered as operational
 #         after <count> consecutive successful health checks. This value defaults to 3. 
@@ -174,12 +174,9 @@ cat <<EOF> $chef_dir/chef.json
     "health_check_uri": "$HEALTH_CHECK_URI",
     "session_stickiness": "$SESSION_STICKINESS",
     "backend": {
-     "inter": "$INTER",
-     "fall": "$FALL",
-     "rise": "$RISE"
-    },
-  "haproxy": {
-    "maxconn": "$MAXCONN"
+     "inter": "$MEMBER_INTER",
+     "fall": "$MEMBER_FALL",
+     "rise": "$MEMBER_RISE"
     },
     $ssl_cert
     $ssl_incoming_port

--- a/haproxy/HAProxy_Install-chef
+++ b/haproxy/HAProxy_Install-chef
@@ -82,6 +82,40 @@
 #     Required: false
 #     Advanced: false
 #     Default: text:/haproxy-status
+#   FALL:
+#     Category: Load Balancer
+#     Description: 'The number of consecutive invalid health checks before considering the server as DOWN. 
+#           Default value is 2.  This is for the backend pool.'
+#     Input Type: single
+#     Required: false
+#     Advanced: false
+#     Default: text:'2'
+#   INTER:
+#     Category: Load Balancer
+#     Description: 'The inter parameter sets the interval between two consecutive health checks
+#         to <delay> milliseconds. If left unspecified, the delay defaults to 2000 ms(2 seconds). 
+#         This is for the backend pool.'
+#     Input Type: single
+#     Required: false
+#     Advanced: false
+#     Default: text:'300'
+#   RISE:
+#     Category: Load Balancer
+#     Description: 'The rise parameter states that a server will be considered as operational
+#         after <count> consecutive successful health checks. This value defaults to 3. 
+#         This is for the backend pool.'
+#     Input Type: single
+#     Required: false
+#     Advanced: false
+#     Default: text:'3'
+#   MAXCONN:
+#     Category: Load Balancer
+#     Description: 'Sets the maximum per-process number of concurrent connections to <number>.
+#        Proxies will stop accepting connections when this limit is reached. This value defaults to 4096.'
+#     Input Type: single
+#     Required: false
+#     Advanced: false
+#     Default: text:'4096'
 # Attachments: []
 # ...
 

--- a/haproxy/HAProxy_Install-chef
+++ b/haproxy/HAProxy_Install-chef
@@ -182,9 +182,9 @@ cat <<EOF> $chef_dir/chef.json
     "health_check_uri": "$HEALTH_CHECK_URI",
     "session_stickiness": "$SESSION_STICKINESS",
     "maxconn":"$MAXCONN",
-    "backend/inter": "$INTER",
-    "backend/rise": "$RISE",
-    "backend/fall": "$FALL",
+    "backend": {"inter":"$INTER"}
+    "backend": {"rise":"$RISE"}
+    "backend": {"fall":"$FALL"}
     $ssl_cert
     $ssl_incoming_port
     $stats_password

--- a/haproxy/HAProxy_Install-chef
+++ b/haproxy/HAProxy_Install-chef
@@ -108,14 +108,6 @@
 #     Required: false
 #     Advanced: false
 #     Default: text:'3'
-#   MAXCONN:
-#     Category: Load Balancer
-#     Description: 'Sets the maximum per-process number of concurrent connections to <number>.
-#        Proxies will stop accepting connections when this limit is reached. This value defaults to 4096.'
-#     Input Type: single
-#     Required: false
-#     Advanced: false
-#     Default: text:'4096'
 # Attachments: []
 # ...
 

--- a/haproxy/server_template.yml
+++ b/haproxy/server_template.yml
@@ -32,10 +32,10 @@ Inputs:
   CHEF_VALIDATION_KEY: blank
   CHEF_VALIDATION_NAME: blank
   COLLECTD_SERVER: env:RS_TSS
-  FALL: blank
-  INTER: blank
-  MAXCONN: blanks
-  RISE: blank
+  FALL: text:2
+  INTER: text:300
+  MAXCONN: text:4096
+  RISE: text:3
   RS_INSTANCE_UUID: env:RS_INSTANCE_UUID
   SSL_CERT: blank
   SSL_INCOMING_PORT: blank

--- a/haproxy/server_template.yml
+++ b/haproxy/server_template.yml
@@ -32,6 +32,10 @@ Inputs:
   CHEF_VALIDATION_KEY: blank
   CHEF_VALIDATION_NAME: blank
   COLLECTD_SERVER: env:RS_TSS
+  FALL: blank
+  INTER: blank
+  MAXCONN: blanks
+  RISE: blank
   RS_INSTANCE_UUID: env:RS_INSTANCE_UUID
   SSL_CERT: blank
   SSL_INCOMING_PORT: blank


### PR DESCRIPTION
Made inter, rise, fall, & maxconn optional inputs that can be updated on ST.  
Added changelog
This is with defaults
![haproxy-with-inputs-defaults_-_server_inputs](https://cloud.githubusercontent.com/assets/5281839/26068703/61da8e38-396c-11e7-8732-f0276e6a33ed.png)

App Server shows this:
tusharshah@haproxy-with-inputs-defaults:~$ cat /usr/local/etc/haproxy/haproxy.cfg
backend FamilyDollarAPI
     server disabled-server 127.0.0.1:1 disabled
     server 03-DUPRS6G5DQH18 10.66.2.101:8080 inter 300 rise 3 fall 2 maxconn 100 check cookie 03-DUPRS6G5DQH18
     server 03-1UINMS7NPONFR 10.66.2.214:8080 inter 300 rise 3 fall 2 maxconn 100 check cookie 03-1UINMS7NPONFR

This is with defaults changed for inter.
haproxy:
![haproxy-with-inputs-defaults_-_server_inputs](https://cloud.githubusercontent.com/assets/5281839/26074110/9f1384aa-397e-11e7-9d59-687af6022c4f.png)

Here is what the app servers show now:



