### PR TITLE
Changed client download URL www.opscode.com -> www.chef.io

### DIFF
--- a/chef-server/CHANGELOG.md
+++ b/chef-server/CHANGELOG.md
@@ -1,5 +1,9 @@
 this is the changelog for Server Templates
 
+v2.0.4
+------
+- updated Chef Client download URI (www.opscode.com -> www.chef.io)
+
 v2.0.3
 ------
 - added VERSION for chef script.

--- a/chef-server/RL10_Chef_Server_Install.sh
+++ b/chef-server/RL10_Chef_Server_Install.sh
@@ -97,7 +97,7 @@ if [[ ! -z $VERSION ]]; then
 fi
 
 if [ ! -e /usr/bin/chef-client ]; then
-  curl -L https://www.opscode.com/chef/install.sh | sudo bash -s -- $version
+  curl -L https://www.chef.io/chef/install.sh | sudo bash -s -- $version
 fi
 
 chef_dir="/home/rightscale/.chef"


### PR DESCRIPTION
Changed client download URL from www.opscode.com (deprecated long ago) to www.chef.io