### PR TITLE
added /var/chef/handlers since it was missing

### DIFF
--- a/mongodb/MongoDB_Install-chef.sh
+++ b/mongodb/MongoDB_Install-chef.sh
@@ -95,6 +95,7 @@ export PATH=${PATH}:/usr/local/sbin:/usr/local/bin
 
 export chef_dir=$HOME/.chef
 mkdir -p $chef_dir
+mkdir -p /var/chef/handlers
 
 #get instance data to pass to chef server
 instance_data=$(/usr/local/bin/rsc --rl10 cm15 index_instance_session  /api/sessions/instance)


### PR DESCRIPTION
After making the change, the backup script works:
![dev-digitaldeals-mongo-01_-_server_audit_entries](https://user-images.githubusercontent.com/5281839/27654289-c32bd866-5c0f-11e7-9d4d-99f4c592f482.png)
