### PR TITLE
fixing issue where catalina_options are passed in passing

### DIFF
--- a/tomcat/Tomcat_Install-chef.sh
+++ b/tomcat/Tomcat_Install-chef.sh
@@ -186,6 +186,7 @@ cat <<EOF> $chef_dir/chef.json
 		"listen_port": "$LISTEN_PORT",
 		"vhost_path": "$VHOST_PATH",
 		"version": "$TOMCAT_VERSION",
+		"catalina_options":"$CATALINA_OPTIONS",
 		"database": {
 			"host": "$DATABASE_HOST",
 			"schema": "$DATABASE_SCHEMA",


### PR DESCRIPTION
fixing issue where catalina_options are passed into startup
ps -ef | grep java.  
Default is 128, we changed it to 256 on input and it took. 
Any value passed into catalina_options will be taken now.
![root_dev-digitaldeals-tomcat-api-29___opt_tomcat_logs_ _-ssh_-l_tusharshah_ec2-34-225-138-136_compute-1_amazonaws_com_ _239x50](https://user-images.githubusercontent.com/5281839/28037153-77fd0f40-6588-11e7-9596-2a564a2d2192.png)

