### PR TITLE
Adding ability to select both mongo 3.0 and 3.4 as an input

### DIFF
--- a/mongodb/CHANGELOG.md
+++ b/mongodb/CHANGELOG.md
@@ -1,0 +1,3 @@
+v2.1
+------
+- adding mongo version 3.4

--- a/mongodb/CHANGELOG.md
+++ b/mongodb/CHANGELOG.md
@@ -1,3 +1,3 @@
-v2.1
+v2.0.5
 ------
 - adding mongo version 3.4

--- a/mongodb/CHANGELOG.md
+++ b/mongodb/CHANGELOG.md
@@ -1,3 +1,4 @@
-v2.0.5
+v2.0.4
 ------
 - adding mongo version 3.4
+- matching version with rsc_mongodb

--- a/mongodb/CHANGELOG.md
+++ b/mongodb/CHANGELOG.md
@@ -1,4 +1,4 @@
-v2.0.4
+v2.0.5
 ------
 - adding mongo version 3.4
 - matching version with rsc_mongodb

--- a/mongodb/MongoDB_Install-chef.sh
+++ b/mongodb/MongoDB_Install-chef.sh
@@ -130,7 +130,6 @@ cat > $chef_dir/chef.json <<-EOF
     "compile_time_update": "true"
   },
   "rs-base": {
-    
     "collectd_hostname": "$instance_uuid"
   },
   "mongodb": {

--- a/mongodb/MongoDB_Install-chef.sh
+++ b/mongodb/MongoDB_Install-chef.sh
@@ -79,6 +79,16 @@
 #     Input Type: single
 #     Required: true
 #     Advanced: false
+#   MONGO_VERSION:
+#     Category: MongoDB
+#     Description: MongoDB Version 3.0 or 3.4.
+#     Input Type: single
+#     Required: true
+#     Advanced: false
+#     Default: text:3.0
+#     Possible Values:
+#      - text:3.0
+#      - text:3.4
 # Attachments: []
 # ...
 
@@ -120,7 +130,7 @@ cat > $chef_dir/chef.json <<-EOF
     "compile_time_update": "true"
   },
   "rs-base": {
-    "collectd_server": "$monitoring_server",
+    
     "collectd_hostname": "$instance_uuid"
   },
   "mongodb": {
@@ -137,7 +147,8 @@ cat > $chef_dir/chef.json <<-EOF
     "restore_from_backup":"$MONGO_RESTORE_FROM_BACKUP",
     "user":"$MONGO_USER",
     "password":"$MONGO_PASSWORD",
-    "restore_lineage_name":"$MONGO_RESTORE_LINEAGE_NAME"
+    "restore_lineage_name":"$MONGO_RESTORE_LINEAGE_NAME",
+    "mongo_version":"$MONGO_VERSION"
   },
   "run_list": ["recipe[apt]","recipe[rsc_mongodb::volume_default]","recipe[rsc_mongodb]"]
 }


### PR DESCRIPTION
@rshade @gonzalez 
mongo replica set restore:
![tusharshah_upgrade-dev-productapi-mongo-01-34____ _-ssh_-l_tusharshah_ec2-34-198-51-71_compute-1_amazonaws_com_ _223x67](https://user-images.githubusercontent.com/5281839/29686591-912201d8-88e7-11e7-8e8f-e7329bf4e452.png)

mongo input on st:
![upgrade-dev-productapi-mongo-01-34_-_server_inputs](https://user-images.githubusercontent.com/5281839/29686725-1353733a-88e8-11e7-87b2-8dea3e24e7c6.png)

mongo backup:
![volume_snapshots](https://user-images.githubusercontent.com/5281839/29686828-65141558-88e8-11e7-94f7-3116c0708865.png)



