### PR TITLE
PASSSET-726: Remove CHEF_SEVER_ADDONS input and code

### DIFF
--- a/chef-server/CHANGELOG.md
+++ b/chef-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+v2.0.6
+------
+- Remove CHEF_SERVER_ADDONS input. Any addons can be installed via 'chef-server-ctl install'
+
 v2.0.5
 ------
 - Totally revamped backup scripts.

--- a/chef-server/chef_server_install.sh
+++ b/chef-server/chef_server_install.sh
@@ -45,14 +45,6 @@
 #     - text:warn
 #     - text:fatal
 #     - text:debug
-#   CHEF_SERVER_ADDONS:
-#     Category: CHEF
-#     Description: A common separated list of chef server addons.  For more details
-#       see https://github.com/chef-cookbooks/chef-server
-#     Input Type: array
-#     Required: true
-#     Advanced: false
-#     Default: array:["text:manage","text:reporting"]
 #   COOKBOOK_VERSION:
 #     Category: CHEF
 #     Description: 'The chef-blue-print cookbook version/branch to use to install chef.  Use
@@ -146,11 +138,6 @@ if [ -e $chef_dir/chef.json ]; then
   rm -f $chef_dir/chef.json
 fi
 
-#convert input array to array for json in chef.json below
-IFS=","
-addons_array=`echo $CHEF_SERVER_ADDONS | awk -v RS='' -v OFS='","' 'NF { $1 = $1; print "\"" $0 "\"" }'`
-IFS=""
-
 chef_version=""
 if [ -n "$CHEF_SERVER_VERSION" ];then
  chef_version="\"version\":\"$CHEF_SERVER_VERSION\","
@@ -168,7 +155,6 @@ cat <<EOF> $chef_dir/chef.json
     "accept_license": true,
     "api_fqdn": "$CHEF_SERVER_FQDN",
     $chef_version
-    "addons":  [$addons_array],
     "configuration":{
     "notification_email":"$CHEF_NOTIFICATON_EMAIL"
     }
@@ -181,7 +167,6 @@ cat <<EOF> $chef_dir/chef.json
 
   "run_list": [
     "recipe[chef-server-blueprint::default]",
-    "recipe[chef-server::addons]",
     "recipe[rsc_postfix::default]"
   ]
 }


### PR DESCRIPTION
The "chef server addons" input in the Chef ST will fail to provision or boot if the addons array input is left empty. This is a RS issue and is currently a bug. If you want to install an older version of Chef, the default inputs in this array could cause an install failure due to incompatibilities. Also, if you want to pin a version of the addon you are installing you have to pass a hash. Unfortunately the way the ST bash code and Chef recipes are setup passing a hash with a version number isn't viable.

None of our current customers use the default addons we are installing. To fix this bug it is easiest to just remove the addon input entirely. If a customer needs to install a paid addon after the Chef Server is configured, they can easily login to the host and just simply do a `chef-server-ctl install <addon>`.

I've tested the new code on CentOS-7 / RHEL-7 / Ubuntu 16.04 and it works as intended.